### PR TITLE
add hook.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ APIs that can receive HTTP requests from your system about an event.
 Resources for API providers and consumers of webhooks.
 - [Fanout Cloud](http://fanout.io/cloud/) - [docs](https://fanout.io/docs/devguide.html#webhooks)
 - [webhooks.io](http://www.webhooks.io) - [docs](http://www.webhooks.io/docs)
-- [WebhookApp](https://webhookapp.com/)
+- [WebhookApp](https://webhookapp.com/) - Test, debug, proxy and replay webhooks
+- [hook.io](https://hook.io/) - Microservice and webhook hosting
 - [Zurl](http://github.com/fanout/zurl) - HTTP client worker with ZeroMQ interface.
 - [RequestBin](http://requestb.in/) - RequestBin gives you a temporary URL that will collect and inspect requests made to it.
 - [WebhookInbox](http://webhookinbox.com/) - Like RequestBin but with live updates.


### PR DESCRIPTION
not exactly a tool for webhooks. this advertises itself as "webhook hosting", but it is more like an HTTP API gateway.