### PR TITLE
Add HookRelay.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Resources for API providers and consumers of webhooks.
 - [hook.io](https://hook.io/) - Microservice and webhook hosting
 - [Hookdeck](https://hookdeck.com/) - Inbound webhook queue supporting fanout, retry, alerting & more
 - [Hooklistener](https://hooklistener.com/) - Managed webhook proxy that lets developers receive, inspect, and replay HTTP requests with ease
-- [HookRelay](https://www.hookrelay.io/) - Webhook reliability platform for buffering, retries, replay, and delivery guarantees
+- [HookRelay.io](https://www.hookrelay.io/) - Webhook reliability platform for buffering, retries, replay, and delivery guarantees
 - [hookrelay](https://www.hookrelay.dev/) - Webhook delivery platform (webhooks as a service)
 - [HostedHooks](https://hostedhooks.com/) - Webhook platform (webhooks as a service)
 - [Inhooks](https://github.com/didil/inhooks) - Lightweight Incoming Webhooks Gateway


### PR DESCRIPTION
Adding HookRelay.io
Webhook reliability platform for buffering, retries, replay, and delivery guarantees