### PR TITLE
Add Webhook Debugger - self-hosted webhook inspector with signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Resources for API providers and consumers of webhooks.
 - [webhooks.events.dev](https://webhooks.events.dev/) - Webhook platform (webhooks as a service)
 - [webhooks.io](http://www.webhooks.io) - [docs](http://www.webhooks.io/docs) Inboud webhook queue
 - [webhook.site](https://webhook.site/) - Inspect, test & automate any incoming HTTP request or e-mail
+- [Webhook Debugger](https://github.com/brancogao/webhook-debugger) - Self-hosted webhook inspector with 90-day history, signature verification (Stripe/GitHub/Slack/Shopify), and real-time debugging.
 - [Webhook Debugger & Logger](https://apify.com/ar27111994/webhook-debugger-logger) - Enterprise-grade webhook inspection, logging, and replay tool with real-time SSE streaming and mock responses.
 - [Webhook Relay](https://webhookrelay.com/) - Inbound webhook gateway for devices not directly connected to the Internet
 - [Webhook Wizard](https://webhookwizard.com/) - Webhook platform (webhooks as a service)


### PR DESCRIPTION
## Description

Added Webhook Debugger - a self-hosted webhook inspection tool with unique features:

- **90-day webhook history** (vs 7 days on most alternatives)
- **Signature verification** for Stripe, GitHub, Slack, Shopify, Twilio, SendGrid, Intercom, Telegram, Discord
- **Easy self-hosting** on Cloudflare Workers + D1 (free tier available)
- **Real-time debugging** with SSE streaming
- **Open source** with MIT license

## Differentiation from existing tools

- **vs webhook.site**: Self-hosted, 90-day history, signature verification
- **vs Webhook Debugger & Logger**: Self-hosted on Cloudflare (not Apify), signature verification, open source

## Checklist

- [x] The entry is alphabetically ordered
- [x] The description follows the existing format
- [x] Link points to the GitHub repository (open source)