### PR TITLE
Add Spiderhash to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Resources for API providers and consumers of webhooks.
 - [Reliable Webhook](https://www.reliablewebhook.com/) - VS Code extension & relay app to help develop webhooks
 - [RequestBin](http://requestb.in/) - RequestBin gives you a temporary URL that will collect and inspect requests made to it.
 - [REST Hooks](http://resthooks.org/) - A collection of patterns that treat webhooks like subscriptions
+- [Spiderhash](https://spiderhash.io/) - Webhook inspection and debugging workspace for testing inbound events and payload workflows
 - [Svix](https://www.svix.com/) - Webhook sending platform (webhooks as a service)
 - [Svix Playground](https://www.svix.com/play/) - Svix version of RequestBin
 - [Ultrahook](http://www.ultrahook.com/) - Receive webhooks on localhost


### PR DESCRIPTION
Adds Spiderhash (https://spiderhash.io/) as a webhook inspection/debugging tool under Development Tools.

Why:
- relevant to incoming webhook testing workflows
- provides request payload inspection/debugging use case
- complements existing tools like webhook.site / RequestBin

Submitted by automation run for project webhook-seo.