### PR TITLE
Add Webhook Inspector to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Resources for API providers and consumers of webhooks.
 - [webhook.site](https://webhook.site/) - Inspect, test, and automate any incoming HTTP request or e-mail.
 - [Webhook Debugger](https://github.com/brancogao/webhook-debugger) - Self-hosted webhook inspector with 90-day history, signature verification (Stripe/GitHub/Slack/Shopify), and real-time debugging.
 - [Webhook Debugger & Logger](https://apify.com/ar27111994/webhook-debugger-logger) - Enterprise-grade webhook inspection, logging, and replay tool with real-time SSE streaming and mock responses.
+- [Webhook Inspector](https://webhook-inspector-landing-one.vercel.app) - Free webhook debugging and inspection tool. Create unique endpoints, capture HTTP callbacks in real-time, inspect headers/body/query params, replay requests. REST API for programmatic access. No signup required.
 - [Webhook Relay](https://webhookrelay.com/) - Inbound webhook gateway for devices not directly connected to the Internet.
 - [Webhook Wizard](https://webhookwizard.com/) - Webhook platform (webhooks as a service).
 - [WebReducer](https://hookreducer.com/) - Inbound webhook queue.


### PR DESCRIPTION
## Summary

This PR adds [Webhook Inspector](https://webhook-inspector-landing-one.vercel.app) to the Development Tools section.

Webhook Inspector is a free webhook debugging and inspection tool that lets developers:
- Create unique endpoints to capture incoming HTTP callbacks in real-time
- Inspect full request details: headers, body, query params, and method
- Replay captured requests for repeated testing
- Use the REST API for programmatic access (useful in CI/CD pipelines)
- No signup or account required

It fits well alongside existing tools like RequestBin, webhook.site, and WebhookInbox in the Development Tools section. The entry is inserted in alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)