### PR TITLE
Add CueAPI to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Resources for API providers and consumers of webhooks.
 - [Boomerang](https://onassar.github.io/experiments/boomerang-webhooks) - Simple delayed webhook delivery.
 - [Charles](http://www.charlesproxy.com/) - Tool to inspect HTTP traffic between your local machine and the internet.
 - [Convoy](http://getconvoy.io/) - Open-source webhooks proxy for sending and receiving events.
+- [CueAPI](https://github.com/cueapi/cueapi-core) - Scheduled outbound webhooks with required outcome verification; handlers POST back a verified outcome (external ID + result URL) after processing, so you can tell which deliveries actually did their job.
 - [EventDock](https://eventdock.app/) - Inbound webhook reliability platform with automatic retries, dead letter queue, and AI anomaly detection. Built on Cloudflare's edge network.
 - [Fanout Cloud](http://fanout.io/cloud/) - [docs](https://docs.fanout.io/docs) - Push platform supporting webhooks.
 - [h00k.dev](https://www.h00k.dev/) - Debug, test, and monitor webhooks.


### PR DESCRIPTION
Adds [CueAPI](https://github.com/cueapi/cueapi-core) to the **Development Tools** section, alphabetically between Convoy and EventDock.

CueAPI is an open-source (Apache 2.0) scheduling layer for outbound webhooks with required outcome verification: you schedule a cron-triggered HTTP POST to your handler, and the handler has to POST back a verified outcome (external ID + result URL) after processing. That makes it usable for cases where you actually need to know whether the webhook did its job, not just whether delivery succeeded.

- Repo: https://github.com/cueapi/cueapi-core
- Docs: https://docs.cueapi.ai

Format matches contributing.md: `- [Name](link) - Description.`, one entry, alphabetical slot, period-terminated. Disclosure: I maintain the project.