### PR TITLE
Add Simplehook to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Resources for API providers and consumers of webhooks.
 - [Reliable Webhook](https://www.reliablewebhook.com/) - VS Code extension and relay app to help develop webhooks.
 - [RequestBin](http://requestb.in/) - Gives you a temporary URL that will collect and inspect requests made to it.
 - [REST Hooks](http://resthooks.org/) - A collection of patterns that treat webhooks like subscriptions.
+- [Simplehook](https://simplehook.dev/) - Receive webhooks at a stable URL with one line of code. Works for servers and AI agents.
 - [Spiderhash](https://spiderhash.io/) - Webhook inspection and debugging workspace for testing inbound events and payload workflows.
 - [Svix](https://www.svix.com/) - Webhook sending platform (webhooks as a service).
 - [Svix Playground](https://www.svix.com/play/) - Svix version of RequestBin.


### PR DESCRIPTION
Hi — adding Simplehook to the Development Tools section.

**What it is:** A webhook delivery service that gives developers a permanent webhook URL (set once in Stripe, GitHub, etc., never changes). The SDK receives events via an outbound WebSocket so events arrive at localhost behind firewalls and NATs, and a Pull API lets AI agents consume the same events.

Alphabetical placement between `REST Hooks` and `Spiderhash`.

- Link: https://simplehook.dev
- Repo: https://github.com/bnbarak/antiwebhook