### PR TITLE
Add Hook0 to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Resources for API providers and consumers of webhooks.
 - [h00k.dev](https://www.h00k.dev/) - Debug, test, and monitor webhooks.
 - [hook.io](https://hook.io/) - Microservice and webhook hosting.
 - [HookCatcher](https://github.com/opspawn/hookcatcher) - Open-source webhook testing and debugging tool with real-time SSE streaming, no signup required.
+- [Hook0](https://www.hook0.com/) - Open-source webhooks-as-a-service platform built in Rust.
 - [Hookdeck](https://hookdeck.com/) - Inbound webhook queue supporting fanout, retry, alerting and more.
 - [Hooklistener](https://hooklistener.com/) - Managed webhook proxy that lets developers receive, inspect, and replay HTTP requests with ease.
 - [HookRelay.io](https://www.hookrelay.io/) - Webhook reliability platform for buffering, retries, replay, and delivery guarantees.


### PR DESCRIPTION
## Summary

- Adds [Hook0](https://www.hook0.com/) to the Development Tools section
- Hook0 is an open-source webhooks-as-a-service (WaaS) platform built in Rust
- 1,400+ GitHub stars: https://github.com/hook0/hook0
- Fits alongside Svix, Convoy, Hookdeck, and other webhook tooling