### PR TITLE
Add HookRay to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Resources for API providers and consumers of webhooks.
 - [Hook0](https://www.hook0.com/) - Open-source webhooks-as-a-service platform built in Rust.
 - [Hookdeck](https://hookdeck.com/) - Inbound webhook queue supporting fanout, retry, alerting and more.
 - [Hooklistener](https://hooklistener.com/) - Managed webhook proxy that lets developers receive, inspect, and replay HTTP requests with ease.
+- [HookRay](https://hookray.com/) - Webhook testing tool with smart parsing for 105+ services. Capture, inspect, replay. Free tier + $9/mo Pro.
 - [HookRelay.io](https://www.hookrelay.io/) - Webhook reliability platform for buffering, retries, replay, and delivery guarantees.
 - [hookrelay](https://www.hookrelay.dev/) - Webhook delivery platform (webhooks as a service).
 - [HostedHooks](https://hostedhooks.com/) - Webhook platform (webhooks as a service).


### PR DESCRIPTION
Hi 👋

Adding HookRay to the **Development Tools** section.

HookRay is a webhook testing platform with:
- Smart parsing for 105+ services (Stripe, GitHub, Shopify, Slack, Twilio, Square, Discord, SendGrid, Plaid, Clerk, Vercel, Supabase, etc.) — auto-highlights the meaningful fields per provider so you don't scroll through giant JSON.
- One-click replay for testing handler code locally
- Free anonymous URLs (100 req/mo, no signup, instant)
- Pro at $9/mo (10K req/mo, persistent URLs, 30-day history, search/replay)

Site: https://hookray.com  
Free webhook URL (no signup): https://hookray.com/app

Inserted alphabetically between **Hooklistener** and **HookRelay.io** in the Development Tools section. Single line addition, no other changes.

Thanks for maintaining this list!