### PR TITLE
Add Snare to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Resources for API providers and consumers of webhooks.
 - [RequestBin](http://requestb.in/) - Gives you a temporary URL that will collect and inspect requests made to it.
 - [REST Hooks](http://resthooks.org/) - A collection of patterns that treat webhooks like subscriptions.
 - [Simplehook](https://simplehook.dev/) - Receive webhooks at a stable URL with one line of code. Works for servers and AI agents.
+- [Snare](https://snare.naptownlabs.dev/) - Webhook tester with live request inspection and forwarding to Slack/Discord.
 - [Spiderhash](https://spiderhash.io/) - Webhook inspection and debugging workspace for testing inbound events and payload workflows.
 - [Svix](https://www.svix.com/) - Webhook sending platform (webhooks as a service).
 - [Svix Playground](https://www.svix.com/play/) - Svix version of RequestBin.


### PR DESCRIPTION
Adds [Snare](https://snare.naptownlabs.dev/), a free webhook tester focused on inspecting incoming HTTP requests in real time and forwarding them on to Slack, Discord, or custom URLs. No signup required for the free tier.

Placed alphabetically between Simplehook and Spiderhash in the Development Tools section.