### PR TITLE
Add EEP (Entity Engagement Protocol) to About Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Tutorials, guides, articles about using webhooks.
 - [7 Reasons Webhooks are Magic](https://www.iron.io/7-reasons-webhooks-are-magic/)
 - [events.dev](https://events.dev/)
 - [CloudEvents event data specification](https://cloudevents.io/)
+- [EEP (Entity Engagement Protocol)](https://eep.dev/)
 
 ## Outgoing
 


### PR DESCRIPTION
Adds EEP to the **About Webhooks** section, alongside the existing protocol/spec entries (Standard Webhooks, CloudEvents).

**What it is:** EEP is an open standard (Apache 2.0) for push-based, signed event delivery between digital entities (people, organizations, products, agents) and the clients that follow them. It builds on CloudEvents v1.0.2, defines HMAC-signed delivery with a 60-second replay window, and adds optional access gates (payment / credential / identity / agreement).

**Why it fits in About Webhooks:** Same category as Standard Webhooks and CloudEvents — a specification, not a SaaS product. Apache 2.0, governance.md, conformance CLI, TS + Python reference SDKs.

- Site: https://eep.dev
- Repo: https://github.com/eep-dev/EEP
- Spec: https://github.com/eep-dev/EEP/blob/main/docs/current/SPECIFICATION.md
- License: Apache 2.0

Entry matches the section's existing minimal style (name + link only).