### PR TITLE
Add rustunnel to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Resources for API providers and consumers of webhooks.
 - [Requex](https://requex.me/) - Webhook testing, mocking, and automated workflows. Capture live requests, mock responses, and trigger automated and customized actions.
 - [RequestBin](http://requestb.in/) - Gives you a temporary URL that will collect and inspect requests made to it.
 - [REST Hooks](http://resthooks.org/) - A collection of patterns that treat webhooks like subscriptions.
+- [rustunnel](https://github.com/joaoh82/rustunnel) - Open-source secure tunnel server in Rust. Forward Stripe/GitHub/Twilio/Slack webhooks to a local handler; capture and replay requests from a dashboard. Self-hosted or managed.
 - [Simplehook](https://simplehook.dev/) - Receive webhooks at a stable URL with one line of code. Works for servers and AI agents.
 - [Snare](https://snare.naptownlabs.dev/) - Webhook tester with live request inspection and forwarding to Slack/Discord.
 - [Spiderhash](https://spiderhash.io/) - Webhook inspection and debugging workspace for testing inbound events and payload workflows.


### PR DESCRIPTION
Hi! I'm Joao (@joaoh82), author of rustunnel — an open-source secure tunnel server in Rust (https://rustunnel.com).

Webhook angle: rustunnel exists in part *for* webhook testing. The hosted dashboard captures every incoming request and lets you replay it against your local handler, which makes iterating on Stripe / GitHub / Twilio / Slack webhook handlers a lot less painful than "send a real event and pray."

Self-hostable on a single VPS; or use the managed multi-region service (free tier; pay-as-you-go after).

- Source: https://github.com/joaoh82/rustunnel
- Docs: https://rustunnel.com/docs
- License: AGPL-3.0

Inserted under **Development Tools**. Happy to adjust description or placement if anything's off.