### PR TITLE
Add FastHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Resources for API providers and consumers of webhooks.
 - [Dodo Payments CLI](https://github.com/dodopayments/dodopayments-cli) - Open-source TUI to listen to live webhooks and forward them to localhost, or trigger test webhook events offline for payment, subscription, refund, dispute and license events.
 - [EventDock](https://eventdock.app/) - Inbound webhook reliability platform with automatic retries, dead letter queue, and AI anomaly detection. Built on Cloudflare's edge network.
 - [Fanout Cloud](http://fanout.io/cloud/) - [docs](https://docs.fanout.io/docs) - Push platform supporting webhooks.
+- [FastHook](https://www.fasthook.io/) - Webhook gateway for routing, inspecting, retrying, replaying, and delivering events to HTTP endpoints, localhost CLI tunnels, Google Sheets, and Gmail.
 - [h00k.dev](https://www.h00k.dev/) - Debug, test, and monitor webhooks.
 - [hook.io](https://hook.io/) - Microservice and webhook hosting.
 - [HookCatcher](https://github.com/opspawn/hookcatcher) - Open-source webhook testing and debugging tool with real-time SSE streaming, no signup required.


### PR DESCRIPTION
## Summary
- Add FastHook to the Development Tools section.
- Include the general docs link.
- Mention delivery to HTTP endpoints, localhost CLI tunnels, Google Sheets, and Gmail.

## Checks
- Verified https://www.fasthook.io/ returns HTTP 200.
- Verified https://www.fasthook.io/docs returns HTTP 200.
- Ran git diff --check.