### PR TITLE
Add HookSniff to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Resources for API providers and consumers of webhooks.
 - [HookRay](https://hookray.com/) - Webhook testing tool with smart parsing for 105+ services. Capture, inspect, replay. Free tier + $9/mo Pro.
 - [HookRelay.io](https://www.hookrelay.io/) - Webhook reliability platform for buffering, retries, replay, and delivery guarantees.
 - [hookrelay](https://www.hookrelay.dev/) - Webhook delivery platform (webhooks as a service).
+- [HookSniff](https://github.com/servetarslan02/HookSniff) - Open-source webhook delivery platform with automatic retries, HMAC-SHA256 signatures (Standard Webhooks), dead letter queue, FIFO ordering, and real-time analytics. Built in Rust and Next.js.
 - [HostedHooks](https://hostedhooks.com/) - Webhook platform (webhooks as a service).
 - [Inhooks](https://github.com/didil/inhooks) - Lightweight incoming webhooks gateway.
 - [java-ngrok](https://github.com/alexdlaird/java-ngrok) - A Java wrapper for ngrok; programmatic tunnels and webhook testing.


### PR DESCRIPTION
Hi! I'd like to add **HookSniff** to the Development Tools section.

**HookSniff** is an open-source webhook delivery platform built in Rust and Next.js that handles sending, receiving, retrying, and monitoring webhooks.

**Key features:**
- Automatic retries with exponential backoff and jitter
- HMAC-SHA256 signatures (Standard Webhooks compliant)
- Dead letter queue for failed deliveries
- FIFO ordering with sequence numbers
- Smart routing (round-robin, failover, weighted)
- Real-time analytics dashboard
- 11 official SDKs (Node.js, Python, Go, Rust, Java, etc.)

**Links:**
- GitHub: https://github.com/servetarslan02/HookSniff
- Live: https://hooksniff.vercel.app
- Docs: https://hooksniff.vercel.app/docs

Thanks for maintaining this awesome list! 🙏