### PR TITLE
Add wanguard-notify to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Resources for API providers and consumers of webhooks.
 - [Svix Playground](https://www.svix.com/play/) - Svix version of RequestBin.
 - [Ultrahook](http://www.ultrahook.com/) - Receive webhooks on localhost.
 - [Vedika API](https://vedika.io) - Vedic astrology API with webhook support.
+- [wanguard-notify](https://github.com/Flowtriq/wanguard-notify) - Alert bridge for Andrisoft Wanguard that forwards DDoS attack notifications to Slack, Discord, PagerDuty, Telegram, Teams, email, and webhooks.
 - [WebhookApp](https://webhookapp.com/) - Test, debug, proxy, and replay webhooks.
 - [WebhookInbox](http://webhookinbox.com/) - Like RequestBin but with live updates.
 - [Webhook.cool](https://webhook.cool/) - Testing tool for receiving and inspecting incoming webhooks.


### PR DESCRIPTION
Adds [wanguard-notify](https://github.com/Flowtriq/wanguard-notify) to the **Development Tools** section.

**wanguard-notify** is an alert bridge that converts DDoS attack notifications from Andrisoft Wanguard into webhook deliveries for Slack, Discord, PagerDuty, Telegram, Microsoft Teams, email, and generic HTTP endpoints.

It bridges legacy monitoring infrastructure to modern webhook-based platforms, similar in spirit to other bridge tools on this list.

- MIT licensed, Python 3.8+, zero external dependencies
- Supports generic webhook endpoints with custom headers
- PagerDuty auto-resolve when attacks end