### PR TITLE
Add AnyHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ APIs that can receive HTTP requests from your system about an event.
 
 Resources for API providers and consumers of webhooks.
 
+- [AnyHook](https://anyhook.net/) - Webhook relay with automatic retries, event log, and replay; keyless quickstart and an MCP server let AI agents set it up without an account.
 - [Boomerang](https://onassar.github.io/experiments/boomerang-webhooks) - Simple delayed webhook delivery.
 - [Charles](http://www.charlesproxy.com/) - Tool to inspect HTTP traffic between your local machine and the internet.
 - [Convoy](http://getconvoy.io/) - Open-source webhooks proxy for sending and receiving events.


### PR DESCRIPTION
Adds AnyHook to Development Tools (alphabetical placement): a webhook relay with automatic retries, event log, and replay. Notable angle for the list: keyless quickstart + an MCP server, so AI agents can bootstrap an endpoint without an account.