### PR TITLE
Add reqdump — open-source HTTP request inspector and webhook debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Resources for API providers and consumers of webhooks.
 - [Postman](https://learning.postman.com/docs/integrations/webhooks/) - Configure custom webhooks in Postman.
 - [pyngrok](https://github.com/alexdlaird/pyngrok) - A Python wrapper for ngrok; programmatic tunnels and webhook testing.
 - [Reliable Webhook](https://www.reliablewebhook.com/) - VS Code extension and relay app to help develop webhooks.
+- [reqdump](https://reqdump-production.up.railway.app) - [GitHub](https://github.com/bakasa/reqdump) - Open-source HTTP request inspector and webhook debugger. No signup required. Create an endpoint in one click, capture any HTTP method, inspect headers/body/query. MIT licensed.
 - [Requex](https://requex.me/) - Webhook testing, mocking, and automated workflows. Capture live requests, mock responses, and trigger automated and customized actions.
 - [RequestBin](http://requestb.in/) - Gives you a temporary URL that will collect and inspect requests made to it.
 - [REST Hooks](http://resthooks.org/) - A collection of patterns that treat webhooks like subscriptions.


### PR DESCRIPTION
Add [reqdump](https://reqdump-production.up.railway.app) to Development Tools section.

## Why reqdump is awesome webhooks

- **One-click endpoints**: Create a unique URL instantly, no signup required
- **Full inspection**: View method, path, headers, query params, body, and timestamp
- **Request replay**: Replay captured requests against any target URL
- **Embeddable badge**: Live request count badge for any README
- **Open source**: MIT licensed, self-hostable on Railway in 2 minutes
- **JSON API**: Integrate with your tools via REST API
- **CORS enabled**: API endpoints support cross-origin requests

It's similar to webhook.site and RequestBin but fully open source with request replay.