### PR TITLE
Add webhook.co to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Resources for API providers and consumers of webhooks.
 - [Vedika API](https://vedika.io) - Vedic astrology API with webhook support.
 - [WebhookApp](https://webhookapp.com/) - Test, debug, proxy, and replay webhooks.
 - [WebhookInbox](http://webhookinbox.com/) - Like RequestBin but with live updates.
+- [webhook.co](https://www.webhook.co/) - Capture, inspect, and replay inbound webhooks; verifies signatures for 141 providers. CLI, API, and MCP server.
 - [Webhook.cool](https://webhook.cool/) - Testing tool for receiving and inspecting incoming webhooks.
 - [webhooks.events.dev](https://webhooks.events.dev/) - Webhook platform (webhooks as a service).
 - [webhooks.io](http://www.webhooks.io) - [docs](http://www.webhooks.io/docs) - Inbound webhook queue.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Resources for API providers and consumers of webhooks.
 - [Vedika API](https://vedika.io) - Vedic astrology API with webhook support.
 - [WebhookApp](https://webhookapp.com/) - Test, debug, proxy, and replay webhooks.
 - [WebhookInbox](http://webhookinbox.com/) - Like RequestBin but with live updates.
-- [webhook.co](https://www.webhook.co/) - Capture, inspect, and replay inbound webhooks; verifies signatures for 141 providers. CLI, API, and MCP server.
+- [webhook.co](https://www.webhook.co/) - Capture, inspect, and replay inbound webhooks; verifies signatures for 140+ providers. CLI, API, and MCP server.
 - [Webhook.cool](https://webhook.cool/) - Testing tool for receiving and inspecting incoming webhooks.
 - [webhooks.events.dev](https://webhooks.events.dev/) - Webhook platform (webhooks as a service).
 - [webhooks.io](http://www.webhooks.io) - [docs](http://www.webhooks.io/docs) - Inbound webhook queue.


### PR DESCRIPTION
Adds **webhook.co** to Development Tools.

A permanent, signed webhook URL (`https://wbhk.my/<token>`) that writes every inbound request to durable storage first, then shows headers and body alongside a signature-verification verdict — 144 providers' schemes are implemented, generated from the same registry the engine runs on. Captured events replay to `http://localhost:3000` with one command, or forward on to your own destinations in order with retries. The same operations are available from a CLI (`wbhk`), a REST API, the dashboard, and an MCP server; TypeScript, Python and Go SDKs are generated from one OpenAPI contract.

- Source (Apache-2.0): https://github.com/webhook-co/webhook
- Docs: https://docs.webhook.co
- Try it without an account: https://www.webhook.co/play

Two things stated plainly rather than left for you to discover: **webhook.co is pre-launch**, so there is a free tier and published prices but nothing is purchasable yet; and while the core is Apache-2.0 and readable, **it is not currently self-hostable** — I would rather say so than have this read as a self-hosted option.

Disclosure: I'm the author.

Checked against contributing.md:

- Format `- [Name](link) - Description.` ✅
- One suggestion, one PR ✅
- Description ends with a period, no trailing whitespace ✅
- Searched the list first — not a duplicate ✅
- Placed in Development Tools, alphabetically between WebhookInbox and Webhook.cool ✅

Updated 2026-07-30: the registry moved 141 → 144 the same day this PR was opened, so the list entry now reads **140+** rather than an exact count that will keep rotting. The one-line entry is unchanged otherwise.

