### PR TITLE
Add Stripe Signature Debugger to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Resources for API providers and consumers of webhooks.
 - [Simplehook](https://simplehook.dev/) - Receive webhooks at a stable URL with one line of code. Works for servers and AI agents.
 - [Snare](https://snare.naptownlabs.dev/) - Webhook tester with live request inspection and forwarding to Slack/Discord.
 - [Spiderhash](https://spiderhash.io/) - Webhook inspection and debugging workspace for testing inbound events and payload workflows.
+- [Stripe Signature Debugger](https://belalmou.github.io/digital-download-security/stripe-signature-debugger.html) - Diagnose why Stripe's `constructEvent` rejects a signature, or generate a valid `Stripe-Signature` header for tests. Runs entirely in the browser; nothing is uploaded.
 - [Svix](https://www.svix.com/) - Webhook sending platform (webhooks as a service).
 - [Svix Playground](https://www.svix.com/play/) - Svix version of RequestBin.
 - [Ultrahook](http://www.ultrahook.com/) - Receive webhooks on localhost.


### PR DESCRIPTION
Adds a free, client-side tool for the single most common Stripe webhook problem: `constructEvent` throwing `No signatures found matching the expected signature`.

It does two things:

- **Diagnoses** a failing signature — computes the same HMAC Stripe does and reports which part disagrees, distinguishing a re-serialised body (the usual cause) from a wrong secret from a stale timestamp outside the 5-minute replay window.
- **Generates** a valid `Stripe-Signature` header, so you can write tests against your own handler.

Notes:

- Runs entirely in the browser via the Web Crypto API. No server, no upload, no analytics, no tracking. It refuses `sk_`/`rk_` keys so an API key cannot be pasted in by mistake.
- MIT licensed, source at https://github.com/BelalMou/digital-download-security
- Inserted alphabetically between Spiderhash and Svix; one line changed.

Disclosure: I built it. The repo it lives in also links a paid starter kit, though the tool and the write-up are free and complete on their own.