### PR TITLE
Add a webhook provider behaviour reference to About Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Tutorials, guides, articles about using webhooks.
 - [events.dev](https://events.dev/)
 - [CloudEvents event data specification](https://cloudevents.io/)
 - [EEP (Entity Engagement Protocol)](https://eep.dev/)
-- [Webhook Provider Reference](https://anyhook.net/providers) - Response budgets, retry schedules and signature schemes for 17 providers, with a primary source per row.
+- [Webhook Provider Reference](https://anyhook.net/providers) - Response budgets, retry schedules and signature schemes for 18 providers, with a primary source per row.
 
 ## Outgoing
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Tutorials, guides, articles about using webhooks.
 - [events.dev](https://events.dev/)
 - [CloudEvents event data specification](https://cloudevents.io/)
 - [EEP (Entity Engagement Protocol)](https://eep.dev/)
+- [Webhook Provider Reference](https://anyhook.net/providers) - Response budgets, retry schedules and signature schemes for 17 providers, with a primary source per row.
 
 ## Outgoing
 


### PR DESCRIPTION
Adds a table of what each sender does when your endpoint is slow or down: response budget, retry schedule, disable threshold and signature scheme, for 18 providers.

The delivery figures come from each vendor's own docs, with the source linked on every row. For the signature schemes I wrote a working verifier per provider, so anything I misread breaks a test before it reaches the table. Where I could not find a source the row says "not verified" instead of carrying a plausible-looking number, and Stripe's budget says "not published" because Stripe does not publish one.

The same data is available as JSON under CC BY 4.0 at https://anyhook.net/providers.json

Filed as its own PR per the one-suggestion-per-PR rule.