### PR TITLE
Add API Status Check to Outgoing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ APIs that will make requests to your system about an event.
 - [123 Contact Form](http://www.123contactform.com/) - [docs](http://www.123contactform.com/docs/123contactform-api-post-webhook/)
 - [ActiveCampaign](http://activecampaign.com) - [docs](http://www.activecampaign.com/api/webhooks.php)
 - [Aftership](https://www.aftership.com/) - [docs](https://www.aftership.com/docs/api/4/webhook)
+- [API Status Check](https://apistatuscheck.com) - [docs](https://apistatuscheck.com/integrations) - Sends Slack and Discord webhooks when a third-party API you depend on goes down or recovers.
 - [Api.ai](https://api.ai/) - [docs](https://docs.api.ai/docs/webhook)
 - [Asana](https://asana.com) - [docs](https://asana.com/developers/api-reference/webhooks)
 - [Automatic](https://automatic.com) - [docs](https://developer.automatic.com/api-reference/#receiving-webhooks)


### PR DESCRIPTION
Adds **API Status Check** to *Outgoing*.

### Why it belongs in Outgoing, not Development Tools

Everything in *Outgoing* fires a webhook at your system when something happens **inside that
vendor** — a form submitted, a charge disputed, a build finished. API Status Check fires one
when a vendor you depend on **stops answering at all**: it probes 285 third-party APIs and
POSTs to your Slack or Discord when one goes down, and again when it recovers.

That is the event no other entry on this list can emit, because it is not an event that
happens inside any one of them. Stripe's webhook tells you a payment failed. It cannot tell
you that Stripe is the reason. The signal has to come from outside the boundary.

The nearest neighbours are the *Development Tools* reliability platforms (Hookdeck, Hook0,
HookRelay), but those make **your own** webhook delivery reliable — retries, DLQ, replay.
Different layer, and this is a producer of events rather than a pipe for them.

### Entry

```
- [API Status Check](https://apistatuscheck.com) - [docs](https://apistatuscheck.com/integrations) - Sends Slack and Discord webhooks when a third-party API you depend on goes down or recovers.
```

Alphabetised between `Aftership` and `Api.ai`, description ends with a period, one PR for
one suggestion, no trailing whitespace, and I searched the README first — no existing entry.

### Disclosure

- **This is my own project**, so please weigh it accordingly.
- It is a hosted commercial service with a free tier. Webhook registration itself requires
  an API key on a paid plan; the status API and badges are public and unauthenticated.
- Polling cadence is hourly, not sub-minute — so it is the right tool for "did this vendor
  break", not for second-granularity SLA measurement. Saying so up front because the
  distinction matters to anyone wiring it into an on-call path.
- Registration endpoint, verified against production before filing:

  ```bash
  curl -X POST https://apistatuscheck.com/api/webhook/slack \
    -H "Content-Type: application/json" \
    -d '{"apiKey": "...", "webhookUrl": "https://hooks.slack.com/services/...", "apis": ["openai", "stripe"]}'
  ```

  It sends a confirmation message to the channel on successful registration.

Happy to move it to *Development Tools*, reword, or close if you read the category line
differently.
