### PR TITLE
Add Stripe Webhook Signature Doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Resources for API providers and consumers of webhooks.
 - [Simplehook](https://simplehook.dev/) - Receive webhooks at a stable URL with one line of code. Works for servers and AI agents.
 - [Snare](https://snare.naptownlabs.dev/) - Webhook tester with live request inspection and forwarding to Slack/Discord.
 - [Spiderhash](https://spiderhash.io/) - Webhook inspection and debugging workspace for testing inbound events and payload workflows.
+- [Stripe Webhook Signature Doctor](https://arling.sk/stripe-webhook-doctor/) - Free, client-side tool that diagnoses Stripe webhook signature verification errors from a description of how your handler reads the body, header, and secret, across Next.js, Express, Django, Rails, Go, .NET, and serverless.
 - [SuaveHooks](https://suavehooks.com/) - Capture, inspect & route webhooks (webhooks as a service). Live tail, transforms, and multi-target delivery.
 - [Svix](https://www.svix.com/) - Webhook sending platform (webhooks as a service).
 - [Svix Playground](https://www.svix.com/play/) - Svix version of RequestBin.


### PR DESCRIPTION
Adds one entry to Development Tools: **Stripe Webhook Signature Doctor** (https://arling.sk/stripe-webhook-doctor/).

What it does: you describe how your webhook handler reads the request body and the `Stripe-Signature` header, and where your `whsec_` secret comes from (framework, e.g. Next.js App/Pages Router, Express, Django, Rails, Go, serverless, etc.). It works out which of Stripe's documented causes explains a signature verification error ("No signatures found matching...", "Timestamp outside the tolerance zone", etc.) and gives a framework-specific fix.

- Runs entirely in the browser (static site, no backend). Nothing you type is sent to a server, and it never asks for your secret's value, only its prefix and source.
- Free, no signup.
- Analytics: anonymous visit/click counts only, via a self-hosted Umami instance.
- Maintained by ARLing s. r. o. (Bratislava, Slovakia). The code is source-visible (view-source is the whole client-side app) but not under an OSS license — all rights reserved, so I placed it in Development Tools rather than claiming it's open source.

Added alphabetically between Spiderhash and SuaveHooks, following CONTRIBUTING.md's format (`- [Name](link) - Description.`).
